### PR TITLE
Adding new method getCustom()

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,24 @@ myCache.getCache('foo3',function(cachedResponse, expiredResponse){
     }
 });
 
+//This method implements the above function by accepting a custom getter function
+// - The custom getter receives a callback function as its argument
+// - The custom getter sends back the data to be cached through the callback function
+myCache.getCustom('foo4', myCustomGetter, function(data){
+    //Returns an empty array by default
+    if(data && typeof data.length !== 'undefined' && data.length == 0){
+        console.log("Nothing found!!");
+    }else{
+        console.log(data); //foo
+    }
+})
+function myCustomGetter(callback){
+    //Do some asynchronous processing here and pass back some data
+    callback('foo');
+}
 
-//And finally for the fun part!! The getMongo() call automates the above function
-//and queries mongoDB in one call:
+//And finally for the fun part!! The getMongo() call automates the above method by
+//creating a custom getter that handles querying mongodb for you!!
 myCache.getMongo('myCollection',{firstName:"David"},function(data){ //returns an array
     if(data.length > 0)
         console.log(data[0].firstName); //David
@@ -124,6 +139,20 @@ myCache.del(key);
 ```javascript
 myCache.flush();
 ```
+
+- - -
+
+**Custom Getter Helper**
+```javascript
+myCache.getCustom(key, customGetter, ttl, callback);
+```
+
+  * **key** is a string that identifies your cached object. [Required]
+  * **customGetter** is a custom function that meets the following requirements: [Required]
+    * **callback arugment** gets passed to your getter by the getCustom method
+    * **callback** gets called by your custom getter to send data back to get cached
+  * **ttl** is a number that sets a custom time to live in seconds for the cached object. [Optional]
+  * **callback** is a callback function that returns the object that was written to cache. [Optional]
 
 - - -
 

--- a/cache.js
+++ b/cache.js
@@ -28,6 +28,63 @@ Cache.prototype.getCache = function(key,callback){
 		callback(this.cache[key].data);
 	}
 }
+Cache.prototype.getCustom = function(key, customGetter, ttl, callback){
+	var _cache = this;
+	if(arguments.length === 3 && typeof ttl !== 'number'){
+		callback = ttl;
+		ttl = this.ttl;
+	} else {
+		ttl = (typeof ttl === 'number') ? ttl : this.ttl;
+	}
+	if(typeof key !== 'string' || key == ''){
+		console.log('Error with mongo-atm: In getCustom(): Invalid/Missing key passed')
+		return null;
+	}else if(typeof customGetter !== 'function'){
+		console.log('Error with mongo-atm: In getCustom(): Missing custom getter function');
+		return null;
+	}else if(typeof callback !== 'function'){
+		console.log('Error with mongo-atm: In getCustom(): Missing required callback function');
+		return null;
+	}
+	_cache.getCache(key, function(cacheResponse, oldData){
+		//Response was cached - pass it back
+		if(cacheResponse)
+			return callback(cacheResponse);
+		//Cached response expired - pass back old data and load new from customGetter
+		else if(typeof oldData !== 'undefined'){
+			callback(oldData);
+			customGetter(function(newData){
+				if(typeof newData !== 'undefined' && newData !== null){
+					_cache.setCache(key, newData, ttl) //No need for callback - user has their data already
+				}
+			})
+		}
+		//No cached response - use getter to set new cache item
+		else{
+			emitter.once('requestCompleted'+key,function(cb){ return function(data){
+					delete _cache.requestQueued[key];
+					return cb(data);
+			}}(callback))
+
+			//Start getter if it hasn't been started
+			if(typeof _cache.requestQueued[key] === 'undefined'){
+				_cache.requestQueued[key] = true;
+				customGetter(function(newData){
+					if(typeof newData !== 'undefined' && newData !== null){
+						_cache.setCache(key,newData, ttl, function(success){
+							if(success)
+								emitter.emit('requestCompleted'+key,newData);
+							else
+								emitter.emit('requestCompleted'+key,[]);
+						});
+					}else{
+						emitter.emit('requestCompleted'+key,[]);
+					}
+				})
+			}
+		}
+	})
+}
 Cache.prototype.getMongo = function(collection,searchObj,options,callback) {
 	var _cache = this;
 	var defaultLimit = 50; //NOTE: forcing a limit if one isn't defined. Bad/Good idea?
@@ -36,8 +93,8 @@ Cache.prototype.getMongo = function(collection,searchObj,options,callback) {
 		options = {};
 	}
 	options = options || {};
-	var mongoClient = options.mongoClient || this.mongoClient;
-	if(typeof mongoClient === 'undefined' || mongoClient === null){
+	options.mongoClient = options.mongoClient || this.mongoClient;
+	if(typeof options.mongoClient === 'undefined' || options.mongoClient === null){
 		console.log('Error with mongo-atm: In getMongo(): No Mongo connection has been defined.')
 		callback(null);
 		return;
@@ -54,53 +111,15 @@ Cache.prototype.getMongo = function(collection,searchObj,options,callback) {
 	options.sort = (typeof options.sort === 'object') ? options.sort : {};
 	options.limit = options.limit || defaultLimit;
 	options.projection = options.projection || {};
-	options.ttl = options.ttl || this.ttl;
+	var ttl = options.ttl || this.ttl;
 	var key = (options.altKey !== "") ? options.altKey : collection + JSON.stringify(searchObj) + JSON.stringify(options,function(k,v){
 		if(k==='mongoClient' || k==='preSetFunction') return undefined; // not a good idea to stringify our mongo client
 		else return v;
 	});
-	_cache.getCache(key,function(cacheResponse,oldData){
-		if(cacheResponse){
-			callback(cacheResponse);
-		}else if(typeof oldData !== "undefined"){
-			callback(oldData);
-			mongoClient.collection(collection).find(searchObj,options.projection,options.queryOptions).sort(options.sort).limit(options.limit).toArray(function(err,results){
-				if(err && _cache.onMongoFail) _cache.onMongoFail(err);
-				if(typeof results !== 'undefined' && !err){ //NOTE: don't want to pollute our cache if the database is down
-					options.preSetFunction(results,function(processedResults){
-						_cache.setCache(key,processedResults,options.ttl,function(success){
-							//NOTE: already performed callback.
-							return;
-						});
-					});
-				}
-			});
-		}else{
-			emitter.once('requestCompleted'+key,function(cb){ return function(data){
-				delete _cache.requestQueued[key];
-				cb(data);
-			}}(callback));
-
-			if(typeof _cache.requestQueued[key] === 'undefined'){
-				_cache.requestQueued[key]=true;
-				mongoClient.collection(collection).find(searchObj,options.projection,options.queryOptions).sort(options.sort).limit(options.limit).toArray(function(err,results){
-					if(err && _cache.onMongoFail){
-						_cache.onMongoFail(err);
-						emitter.emit('requestCompleted'+key,[]); //???
-					}
-					if(typeof results !== 'undefined' && !err){
-						options.preSetFunction(results,function(processedResults){
-							_cache.setCache(key,processedResults,options.ttl,function(success){
-								if(success)
-									emitter.emit('requestCompleted'+key,processedResults);
-								else emitter.emit('requestCompleted'+key,[]);
-							});
-						});
-					} else {emitter.emit('requestCompleted'+key,[]);}
-				});
-			}
-		}
-	});
+	var mongoGetter = createMongoGetter(collection, searchObj, options, _cache.onMongoFail);
+	//Run getCustom with the custom mongo getter
+	_cache.getCustom(key, mongoGetter, ttl, callback);
+	return;
 };
 Cache.prototype.setCache = function(key,data,ttl,callback){
 	if(arguments.length === 3 && typeof ttl !== 'number'){
@@ -124,6 +143,20 @@ Cache.prototype.flush = function(){
 }
 Cache.prototype.del = function(key){
 	this.cache[key] = {};
+}
+
+function createMongoGetter(collection, searchObj, options, onMongoFail){
+	//Pass back our getter function
+	return function(cb){
+		options.mongoClient.collection(collection).find(searchObj,options.projection,options.queryOptions).sort(options.sort).limit(options.limit).toArray(function(err,results){
+			if(err && typeof onMongoFail == 'function') return onMongoFail(err);
+			if(typeof results !== 'undefined' && !err){ //NOTE: don't want to pollute our cache if the database is down
+				options.preSetFunction(results,function(processedResults){
+					return cb(processedResults);
+				});
+			}
+		});
+	}
 }
 function trimCache(obj, limit){
 	//for now this just removes the oldest item in the object. The alternative would be to convert to array, sort, 


### PR DESCRIPTION
getCustom completely replicates the core functionality of getMongo except that instead of querying mongodb, it receives a custom getter function provided by the client.

The custom getter function must be capable of receiving a callback function sent by getCustom, and must send back data to be cached through that same callback function.  getCustom will handle calling the custom getter whenever it needs to.

In turn, getMongo functions the same, but now it creates the custom mongodb getter on the fly and simply calls getCustom.

Purpose:
Prevent having to replicate the cool functionality of getMongo's get outside of the library (especially in light of recent EventEmitter additions).